### PR TITLE
Set ENABLE_COLORS in meson.build

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -142,6 +142,8 @@ else
 endif
 conf.set('ENABLE_LIRC', enable_lirc)
 
+conf.set('ENABLE_COLORS', curses_color)
+
 common_cflags = [
 ]
 


### PR DESCRIPTION
The option seems to have fallen through the cracks when switching to Meson.