### PR TITLE
Fix blank progressbar when colors are not in use

### DIFF
--- a/src/ProgressBar.cxx
+++ b/src/ProgressBar.cxx
@@ -19,6 +19,7 @@
 
 #include "ProgressBar.hxx"
 #include "colors.hxx"
+#include "options.hxx"
 
 #include <assert.h>
 
@@ -26,7 +27,10 @@ ProgressBar::ProgressBar(Point p, unsigned _width)
 	:window(p, {_width, 1u})
 {
 	leaveok(window.w, true);
-	wbkgd(window.w, COLOR_PAIR(COLOR_PROGRESSBAR));
+#ifdef ENABLE_COLORS
+	if (options.enable_colors)
+		wbkgd(window.w, COLOR_PAIR(COLOR_PROGRESSBAR));
+#endif
 }
 
 void


### PR DESCRIPTION
When moving wbkgd() call in 9c22a95 it was not conditional like it was
for others (commits 7946611 and 6b337bc), which caused progress bar to
not show.