### PR TITLE
Enqueue from search list goes to wrong song

### DIFF
--- a/src/Queue.cxx
+++ b/src/Queue.cxx
@@ -90,7 +90,7 @@ MpdQueue::FindUri(const char *filename) const
 	for (size_type i = 0; i < size(); ++i) {
 		const auto &song = (*this)[i];
 		if (strcmp(mpd_song_get_uri(&song), filename) == 0)
-			return i;
+			return mpd_song_get_id(&song);
 	}
 
 	return -1;


### PR DESCRIPTION
My previous commit was way wrong and only somewhat worked coincidentally - index has nothing to do with mpd song id.

Also fixes #27, since these are different symptoms of th same bug.
