### PR TITLE
Fix unique_ptr error with some old toolchains

### DIFF
--- a/src/screen.cxx
+++ b/src/screen.cxx
@@ -56,8 +56,9 @@ ScreenManager::MakePage(const struct screen_functions &sf)
 		return i;
 
 	auto j = pages.emplace(&sf,
-			       sf.init(*this, main_window.w,
-				       main_window.size));
+			       std::unique_ptr<Page>(sf.init(*this,
+							     main_window.w,
+							     main_window.size)));
 	assert(j.second);
 	return j.first;
 }


### PR DESCRIPTION
With some "old" toolchains (glibc, uclibc in version 4.9.4, 5.3, 5.4,
5.5 ...), the following error is raised by the compiler:

../src/screen.cxx:60:29:   required from here
/usr/lfs/v0/rc-buildroot-test/scripts/instance-1/output/host/opt/ext-toolchain/mips-linux-gnu/include/c++/5.3.0/ext/new_allocator.h:120:4:
error: no matching function for call to 'std::pair<const screen_functions* const, std::unique_ptr<Page> >::pair(const screen_functions*, Page*)'

[...]

/usr/lfs/v0/rc-buildroot-test/scripts/instance-1/output/host/opt/ext-toolchain/mips-linux-gnu/include/c++/5.3.0/bits/stl_pair.h:112:26:
note: candidate: constexpr std::pair<_T1, _T2>::pair(const _T1&, const _T2&) [with _T1 = const screen_functions* const; _T2 = std::unique_ptr<Page>]
       _GLIBCXX_CONSTEXPR pair(const _T1& __a, const _T2& __b)
                          ^
/usr/lfs/v0/rc-buildroot-test/scripts/instance-1/output/host/opt/ext-toolchain/mips-linux-gnu/include/c++/5.3.0/bits/stl_pair.h:112:26:
note:   no known conversion for argument 2 from 'Page*' to 'const
std::unique_ptr<Page>&'

This is due to the fact that init function of screen_functions
structure returns Page* but PageMap wants a std::unique_ptr<Page>

To fix this, cast raw pointer into a unique_ptr with an explicit cast

Fixes:
 - http://autobuild.buildroot.net/results/d8a7339d8bdd5cdc6bd1716585d4bcf15a2e8015

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>