### PR TITLE
ProgressBar: fix 'progressbar-background' doc entry

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -258,7 +258,7 @@ text color used to display playlists in the browser window.
 :command:`color progressbar = COLOR[,ATTRIBUTE]...` - Set the color of
 the progress indicator.
 
-:command:`color progressbar = COLOR[,ATTRIBUTE]...` - Set the color of
+:command:`color progressbar-background = COLOR[,ATTRIBUTE]...` - Set the color of
 the progress indicator background.
 
 :command:`color status-state = COLOR[,ATTRIBUTE]...` - Set the text


### PR DESCRIPTION
The 'progressbar-background' option was added in 74c9243 ("ProgressBar:
dark gray background line", 2018-02-25).  The documentation incorrectly
refers to 'progressbar'.

This is just a minor typo-fix.