### PR TITLE
Fixed manual install dir

### DIFF
--- a/doc/meson.build
+++ b/doc/meson.build
@@ -30,9 +30,9 @@ endif
 if get_option('manual')
   custom_target(
     'Manpage documentation',
-    output: 'man',
+    output: 'man1',
     input: ['index.rst', 'conf.py'],
-    command: [sphinx, '-q', '-b', 'man', '-d', '@OUTDIR@/man_doctrees', meson.current_source_dir(), '@OUTPUT@/man1'],
+    command: [sphinx, '-q', '-b', 'man', '-d', '@OUTDIR@/man_doctrees', meson.current_source_dir(), '@OUTPUT@'],
     build_by_default: true,
     install: true,
     install_dir: get_option('mandir'),


### PR DESCRIPTION
This is a fix for #41.
I'd rather use "mandir" built-in option instead of "datadir" as done in mpc.
But I let you decide which is the best solution, I'm not meson fluent at all.