### PR TITLE
meson.build: add atomic dependency for sparc

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -174,6 +174,9 @@ else
   pcre_dep = declare_dependency()
 endif
 
+# Needed on sparc 
+atomic_dep = cc.find_library('atomic', required: false)
+
 inc = include_directories(
   'src',
 
@@ -352,6 +355,7 @@ ncmpc = executable('ncmpc',
   sources,
   include_directories: inc,
   dependencies: [
+    atomic_dep,
     thread_dep,
     boost_dep,
     pcre_dep,

--- a/src/TagListPage.cxx
+++ b/src/TagListPage.cxx
@@ -38,7 +38,7 @@ TagListPage::MakeCursorFilter() const noexcept
 	unsigned i = lw.selected;
 	if (parent != nullptr) {
 		if (i == 0)
-			return {};
+			return {{}};
 
 		--i;
 	}


### PR DESCRIPTION
Linking with libatomic is needed on sparc otherwise build fails on:
ncmpc@exe/src_Main.cxx.o: In function `std::__atomic_base<long>::operator++()':
/home/buildroot/autobuild/instance-1/output/host/opt/ext-toolchain/sparc-buildroot-linux-uclibc/include/c++/6.4.0/bits/atomic_base.h:296: undefined reference to `__atomic_fetch_add_4'

Fixes:
 - http://autobuild.buildroot.org/results/7ac1a07e4f72633d3ec92b79dc5d8c062490abdc

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>