### PR TITLE
src/TagListPage.cxx: fix build with gcc 5

### DIFF
--- a/src/TagListPage.cxx
+++ b/src/TagListPage.cxx
@@ -38,7 +38,7 @@ TagListPage::MakeCursorFilter() const noexcept
 	unsigned i = lw.selected;
 	if (parent != nullptr) {
 		if (i == 0)
-			return {};
+			return {{}};
 
 		--i;
 	}


### PR DESCRIPTION
Build with gcc 5 fails on:

FAILED: ncmpc@exe/src_TagListPage.cxx.o
/accts/mlweber1/rclinux/rc-buildroot-test/scripts/instance-0/output/host/bin/mips-linux-gnu-g++ -Incmpc@exe -I. -I.. -I../src -I../ -I/accts/mlweber1/rclinux/rc-buildroot-test/scripts/instance-0/output/host/usr/bin/../mips64el-buildroot-linux-gnu/sysroot/usr/include -fdiagnostics-color=always -pipe -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Wnon-virtual-dtor -std=c++14 -O3 -DBOOST_NO_IOSTREAM -DBOOST_ERROR_CODE_HEADER_ONLY -DBOOST_SYSTEM_NO_DEPRECATED -Wall -Wextra -Wno-deprecated-declarations -Wshadow -Wpointer-arith -Wcast-qual -Wcast-align -Wwrite-strings -Wmissing-declarations -Wmissing-noreturn -Wmissing-format-attribute -Wredundant-decls -Wundef -Wno-non-virtual-dtor -fvisibility=hidden -ffunction-sections -fdata-sections -D_GNU_SOURCE -D_DEFAULT_SOURCE -pthread -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 -Os -MD -MQ 'ncmpc@exe/src_TagListPage.cxx.o' -MF 'ncmpc@exe/src_TagListPage.cxx.o.d' -o 'ncmpc@exe/src_TagListPage.cxx.o' -c ../src/TagListPage.cxx
../src/TagListPage.cxx: In member function 'TagFilter TagListPage::MakeCursorFilter() const':
../src/TagListPage.cxx:41:12: error: converting to 'TagFilter {aka std::forward_list<std::pair<mpd_tag_type, std::__cxx11::basic_string<char> > >}' from initializer list would use explicit constructor 'std::forward_list<_Tp, _Alloc>::forward_list(const _Alloc&) [with _Tp = std::pair<mpd_tag_type, std::__cxx11::basic_string<char> >; _Alloc = std::allocator<std::pair<mpd_tag_type, std::__cxx11::basic_string<char> > >]'
    return {};

Fix this error by returning {{}} (a list with one empty element) instead
of {}, see:
https://stackoverflow.com/questions/26947704/implicit-conversion-failure-from-initializer-list

Fixes:
 - http://autobuild.buildroot.org/results/655eb4905c6e308d34293658acee4fc4e1fe0bbc

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>