### PR TITLE
Fix logic to allow for 'none' as object background color.

### DIFF
--- a/src/Styles.cxx
+++ b/src/Styles.cxx
@@ -266,7 +266,7 @@ ParseStyle(StyleData &d, const char *str)
 		if (slash != nullptr) {
 			const char *name = slash + 1;
 			short color = ParseBackgroundColor(name);
-			if (color < 0) {
+			if (color == COLOR_ERROR) {
 				fprintf(stderr, "%s: %s\n",
 					_("Unknown color"), name);
 				return false;


### PR DESCRIPTION
Checking for color < 0 doesn't allow for the case where otherwise valid 'none' value is specified as a background color. I have changed this to be consistent with the check for the 'color background' processing.