### PR TITLE
match: initialize member

### DIFF
--- a/src/Match.hxx
+++ b/src/Match.hxx
@@ -31,7 +31,7 @@
 
 class MatchExpression {
 #ifndef HAVE_PCRE
-	const char *expression;
+	const char *expression = nullptr;
 	size_t length;
 	bool anchored;
 #else


### PR DESCRIPTION
When compiled without pcre support, search will crash out due to
an assertion on the unititialized *expression*:

    ==1183== Conditional jump or move depends on uninitialised value(s)
    ==1183==    at 0x430F9A: MatchExpression::Compile(char const*, bool) (Match.cxx:36)
    ==1183==    by 0x43C008: ListWindow::Find(ListText const&, char const*, bool, bool) (ListWindow.cxx:78)
    ==1183==    by 0x435960: screen_find(ScreenManager&, ListWindow&, Command, ListText const&) (screen_find.cxx:72)

Initialize it to NULL as expected by the assertion.

Signed-off-by: Philipp Gesang <phg@phi-gamma.net>