### PR TITLE
Update FSF terms statement in lyrics plugins

### DIFF
--- a/lyrics/10-hd.sh
+++ b/lyrics/10-hd.sh
@@ -12,9 +12,10 @@
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
-#  You should have received a copy of the GNU General Public License
-#  along with this program; if not, write to the Free Software
-#  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
 #

--- a/lyrics/20-lyricwiki.rb
+++ b/lyrics/20-lyricwiki.rb
@@ -12,9 +12,10 @@
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
-#  You should have received a copy of the GNU General Public License
-#  along with this program; if not, write to the Free Software
-#  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
 #


### PR DESCRIPTION
Fedora's package checker `rpmlint` flagged the lyrics plugin files as having an outdated physical mailing address for the Free Software Foundation in their header comments.

I pulled in the statement as provided in the COPYING file, it had already been updated there.