### PR TITLE
fix: add missing include for signal.h

### DIFF
--- a/src/signals.cxx
+++ b/src/signals.cxx
@@ -16,6 +16,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
+#include <signal.h>
 #include "Instance.hxx"
 
 void


### PR DESCRIPTION
```
FAILED: ncmpc.p/src_signals.cxx.o 
clang++ -Incmpc.p -I. -I.. -Isrc -I../src -I/usr/local/include -I/usr/local/Cellar/pcre/8.44/include -I/usr/local/Cellar/libmpdclient/2.19_1/include -Xclang -fcolor-diagnostics -pipe -Wall -Winvalid-pch -Wnon-virtual-dtor -Wextra -Wpedantic -std=c++17 -O3 -D_GNU_SOURCE -DBOOST_NO_IOSTREAM -DBOOST_ERROR_CODE_HEADER_ONLY -DBOOST_SYSTEM_NO_DEPRECATED -Wall -Wextra -Wno-deprecated-declarations -Wshadow -Wpointer-arith -Wcast-qual -Wcast-align -Wwrite-strings -Wmissing-declarations -Wmissing-noreturn -Wmissing-format-attribute -Wredundant-decls -Wundef -Wno-non-virtual-dtor -fvisibility=hidden -ffunction-sections -fdata-sections -DBOOST_ALL_NO_LIB -MD -MQ ncmpc.p/src_signals.cxx.o -MF ncmpc.p/src_signals.cxx.o.d -o ncmpc.p/src_signals.cxx.o -c ../src/signals.cxx
../src/signals.cxx:36:2: error: use of undeclared identifier 'sigemptyset'
        sigemptyset(&act.sa_mask);
        ^
../src/signals.cxx:39:6: error: no matching constructor for initialization of 'sigaction'
        if (sigaction(SIGPIPE, &act, nullptr) < 0) {
            ^         ~~~~~~~~~~~~~~~~~~~~~~
```

relates to https://github.com/MusicPlayerDaemon/ncmpc/issues/82
relates to https://github.com/Homebrew/homebrew-core/pull/67603