### PR TITLE
(do not merge) ListCursor: fix cursor centering for large scroll offset

### DIFF
--- a/src/ListCursor.cxx
+++ b/src/ListCursor.cxx
@@ -107,6 +107,9 @@ ListCursor::ScrollTo(unsigned n) noexcept
 	if (n >= start + GetHeight() - scroll_offset)
 		new_start = n - GetHeight() + 1 + scroll_offset;
 
+	if (scroll_offset * 2 == GetHeight())
+		new_start = n - GetHeight() + scroll_offset;
+
 	if (new_start + GetHeight() > length)
 		new_start = length - GetHeight();
 
@@ -208,6 +211,8 @@ ListCursor::MoveCursorBottom() noexcept
 	if (length >= GetHeight())
 		if (start + GetHeight() == length)
 			MoveCursor(length - 1);
+		else if (scroll_offset * 2 == GetHeight())
+			MoveCursor(start + GetHeight() - scroll_offset);
 		else
 			MoveCursor(start + GetHeight() - 1 - scroll_offset);
 	else

--- a/src/ListCursor.hxx
+++ b/src/ListCursor.hxx
@@ -309,9 +309,7 @@ private:
 	static constexpr unsigned ClampScrollOffset(unsigned scroll_offset,
 						    unsigned height) noexcept
 	{
-		return scroll_offset * 2 < height
-			? scroll_offset
-			: std::max(height / 2, 1U) - 1;
+		return scroll_offset * 2 < height ? scroll_offset : height / 2;
 	}
 
 	gcc_pure


### PR DESCRIPTION
Problems:
Fixes some remaining issues regarding scroll_offset after #72 and #84.

What it does:
Overall I want to do one thing: put the cursor at the exact middle line for a large `scroll_offset`. When the user sets a large offset, the cursor now centers at the middle line ((height + 1) / 2) for an odd Height() or the line just below the middle (height / 2 + 1) for an even Height().

I tested with some edge cases (different screen height and offset).

What changed:
This PR changes the `ClampScrollOffset` to return half the height instead of height / 2 - 1. The latter will leave a 3-lines space for the cursor for an odd list height instead of limit the cursor to the exact middle line.
For even list height, it's trickier. I added back some checks similar to the spacial cases removed before, just to deal with one exact case. Otherwise, the cursor can not be fixed to one position. I couldn't find better solutions :(