### PR TITLE
build: Find some way to remove rsync dependency

### DIFF
--- a/doc/meson.build
+++ b/doc/meson.build
@@ -17,18 +17,6 @@ if get_option('html_manual')
     install: true,
     install_dir: join_paths(get_option('datadir'), 'doc', meson.project_name()),
   )
-
-  custom_target(
-    'upload',
-    input: sphinx_output,
-    output: 'upload',
-    build_always_stale: true,
-    command: [
-      'rsync', '-vpruz', '--delete', '@INPUT@',
-      'www.musicpd.org:/var/www/mpd/doc/ncmpc/',
-      '--chmod=a+rX',
-    ],
-  )
 endif
 
 if get_option('manual')


### PR DESCRIPTION
Is it possible to handle the `upload` target in `doc/meson.build` in some other fashion, a way that's external to the build process?

The reason being, having that rule there creates a build-time dependency on `rsync`, and the build will fail if it's not installed — meson won't even generate the build system, it just errors out.
```meson
Run-time dependency threads found: YES
Run-time dependency Boost found: YES 1.75.0 (/usr)
Run-time dependency libmpdclient found: YES 2.19
Run-time dependency libpcre found: YES 8.44
Configuring Features.h using configuration
Configuring config.h using configuration
Program sphinx-build found: YES (/usr/bin/sphinx-build)
Program rsync found: NO

doc/meson.build:21:2: ERROR: Program 'rsync' not found
```

I just finished adding a patch to the Fedora package spec for ncmpc that will remove the `upload` target before  generating, since it was preventing us from building ncmpc for Fedora 35. rsync isn't a dependency of ncmpc, so requiring it for the build to run (when it's not even going to be used) seems less than ideal.