### PR TITLE
meson: do not require rsync to build

### DIFF
--- a/doc/meson.build
+++ b/doc/meson.build
@@ -24,7 +24,8 @@ if get_option('html_manual')
     output: 'upload',
     build_always_stale: true,
     command: [
-      'rsync', '-vpruz', '--delete', '@INPUT@',
+      find_program('rsync', required: false, disabler: true)
+      , '-vpruz', '--delete', '@INPUT@',
       'www.musicpd.org:/var/www/mpd/doc/ncmpc/',
       '--chmod=a+rX',
     ],

--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 project('ncmpc', 'cpp',
   version: '0.46',
-  meson_version: '>= 0.47',
+  meson_version: '>= 0.49',
   default_options: [
     'cpp_std=c++17',
     'warning_level=3',


### PR DESCRIPTION
Due to https://github.com/mesonbuild/meson/issues/8641 the latest versions of meson now check that the first argument to run_target is a found executable.

This causes rsync to become explicitly required even though it is only used for maintainer targets... there are essentially 3 solutions:

- explicit find_program and only define the target if rsync is found
- explicit find_program with a disabler that auto-disables the target if
  not found
- run the program "env rsync", since env is basically always available
  and will in turn run rsync -- but meson doesn't know that rsync is
  "needed"

Options 1 and 2 conveniently hide the maintainer target from people who do not care, and the disabler is slightly shorter.


Fixes #101