### PR TITLE
ListCursor: fix cursor centering for large scroll offset

### DIFF
--- a/src/ListCursor.cxx
+++ b/src/ListCursor.cxx
@@ -104,7 +104,7 @@ ListCursor::ScrollTo(unsigned n) noexcept
 	if (n < start + scroll_offset)
 		new_start = n - scroll_offset;
 
-	if (n >= start + GetHeight() - scroll_offset)
+	if (n >= new_start + GetHeight() - scroll_offset)
 		new_start = n - GetHeight() + 1 + scroll_offset;
 
 	if (new_start + GetHeight() > length)
@@ -139,12 +139,17 @@ ListCursor::MoveCursor(unsigned n) noexcept
 void
 ListCursor::FetchCursor() noexcept
 {
+	unsigned int target = selected;
+
 	if (start > 0 &&
-	    selected < start + scroll_offset)
-		MoveCursor(start + scroll_offset);
-	else if (start + GetHeight() < length &&
-		 selected > start + GetHeight() - 1 - scroll_offset)
-		MoveCursor(start + GetHeight() - 1 - scroll_offset);
+	    target < start + scroll_offset)
+		target = start + scroll_offset;
+
+	if (start + GetHeight() < length &&
+		 target > start + GetHeight() - 1 - scroll_offset)
+		target = start + GetHeight() - 1 - scroll_offset;
+
+	MoveCursor(target);
 }
 
 ListWindowRange

--- a/src/ListCursor.cxx
+++ b/src/ListCursor.cxx
@@ -194,8 +194,10 @@ ListCursor::MoveCursorTop() noexcept
 {
 	if (start == 0)
 		MoveCursor(start);
-	else
+	else if (start + scroll_offset < start + GetHeight() - 1 - scroll_offset)
 		MoveCursor(start + scroll_offset);
+	else
+		MoveCursor(start + GetHeight() - 1 - scroll_offset);
 }
 
 void

--- a/src/ListCursor.cxx
+++ b/src/ListCursor.cxx
@@ -81,8 +81,8 @@ ListCursor::Center(unsigned n) noexcept
 {
 	highlight_cursor = false;
 
-	if (n > GetHeight() / 2)
-		start = n - GetHeight() / 2;
+	if (n > (GetHeight() - 1) / 2)
+		start = n - (GetHeight() - 1) / 2;
 	else
 		start = 0;
 
@@ -197,7 +197,7 @@ void
 ListCursor::MoveCursorMiddle() noexcept
 {
 	if (length >= GetHeight())
-		MoveCursor(start + GetHeight() / 2);
+		MoveCursor(start + (GetHeight() - 1) / 2);
 	else
 		MoveCursor(length / 2);
 }

--- a/src/ListCursor.hxx
+++ b/src/ListCursor.hxx
@@ -307,9 +307,7 @@ private:
 	static constexpr unsigned ClampScrollOffset(unsigned scroll_offset,
 						    unsigned height) noexcept
 	{
-		return scroll_offset * 2 < height
-			? scroll_offset
-			: std::max(height / 2, 1U) - 1;
+		return std::min(scroll_offset, height / 2);
 	}
 
 	[[gnu::pure]]


### PR DESCRIPTION
I once made PR #97, but there were some issues with that version. This new one should work much better. This fixes some remaining issues regarding scroll_offset after #72 and #84.

The commit changes the current behavior: If the scroll offset is large (more than half screen height), the cursor now centers at a single line (height-1)/2. This is similar to ncmpcpp or vim behavior. The old behavior is that the cursor can still move within 2 (even height) or 3 (odd height) lines.

The commit mainly contains three type of changes:
- Change the centered position from height/2 to (height-1)/2
- Change the offset as close to height/2 as possible
- Deal with the new special case, scroll_offset * 2 == height

Tested cases:
- Large scroll offset for all cases:
  - Odd and even height for all cases: 
    - Select up and down to check if cursor centers at line (height-1)/2 
    - Use H/M/L keys to navigate top/middle/bottom 
    - Play (Return key) a song to check auto-center option 
    - Scroll in Help or Song pages, it should scroll one line at a time