### PR TITLE
README: Bump Meson version to 0.49

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@ You need:
 - a C++20 compliant compiler (e.g. gcc or clang)
 - `libmpdclient <https://www.musicpd.org/libs/libmpdclient/>`__ 2.16
 - `ncurses <https://www.gnu.org/software/ncurses/>`__
-- `Meson 0.47 <http://mesonbuild.com/>`__ and `Ninja <https://ninja-build.org/>`__
+- `Meson 0.49 <http://mesonbuild.com/>`__ and `Ninja <https://ninja-build.org/>`__
 
 Optional:
 


### PR DESCRIPTION
Commit ae70599bf9000b6380beca2ff0af78350c022be6
raised the Meson version requirement from 0.47 to 0.49.