### PR TITLE
GitHub Actions: Name workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,5 @@
 ---
+name: CI
 on:
   workflow_dispatch:
   push:


### PR DESCRIPTION
Right now, GitHub Actions identifies the CI runs with the rather unwieldy name "`.github/workflows/build.yml`". Adding an explicit "`name: CI`' to the workflow file will shorten that considerably.