### PR TITLE
Remove totally-reachable "unreachable" assert

### DIFF
--- a/src/KeyDefPage.cxx
+++ b/src/KeyDefPage.cxx
@@ -300,8 +300,6 @@ CommandKeysPage::OnCommand(struct mpdclient &c, Command cmd)
 		return false;
 	}
 
-	/* unreachable */
-	assert(0);
 	return false;
 }
 


### PR DESCRIPTION
The presence of `if()` conditions in the `switch`'s `case:` statements means that, anytime one of those conditions is NOT true, the `case:` **doesn't** `return`, and the `return false;` after the `switch` becomes _totally_ reachable.

Fixes: #125