### PR TITLE
Use `/usr/bin/env python3` for script shebangs

### DIFF
--- a/lyrics/20-azlyrics.py
+++ b/lyrics/20-azlyrics.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 #
 #  Copyright 2004-2021 The Music Player Daemon Project
 #  http://www.musicpd.org/

--- a/lyrics/30-karaoke_texty.py
+++ b/lyrics/30-karaoke_texty.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 #
 #  Copyright 2004-2021 The Music Player Daemon Project
 #  http://www.musicpd.org/

--- a/lyrics/40-tekstowo.py
+++ b/lyrics/40-tekstowo.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 #
 #  Copyright 2004-2021 The Music Player Daemon Project
 #  http://www.musicpd.org/

--- a/lyrics/50-genius.py
+++ b/lyrics/50-genius.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 #
 #  Copyright 2004-2021 The Music Player Daemon Project
 #  http://www.musicpd.org/

--- a/lyrics/51-supermusic.py
+++ b/lyrics/51-supermusic.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 #
 #  Copyright 2004-2021 The Music Player Daemon Project
 #  http://www.musicpd.org/

--- a/lyrics/52-zeneszoveg.py
+++ b/lyrics/52-zeneszoveg.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 #
 #  Copyright 2004-2021 The Music Player Daemon Project
 #  http://www.musicpd.org/

--- a/lyrics/60-google.py
+++ b/lyrics/60-google.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 #
 #  Copyright 2004-2021 The Music Player Daemon Project
 #  http://www.musicpd.org/


### PR DESCRIPTION
This supports using whichever `python3` comes first in $PATH, whether that be the system `python3` or one in a venv or somewhere else. Users using a venv will need to install the script dependencies (e.g. bs4, requests) instead of using their package manager. Alternately, users may simply launch `ncmpc` with their system's `python3` first in their `$PATH`.