### PR TITLE
macOS: fix for missing u_int32_t; provide correct declaration for environ

### DIFF
--- a/src/net/IPv4Address.hxx
+++ b/src/net/IPv4Address.hxx
@@ -38,6 +38,10 @@ class IPv4Address {
 	typedef uint32_t in_addr_t;
 #endif
 
+#ifdef __APPLE__
+    typedef uint32_t u_int32_t;
+#endif
+
 	static constexpr in_addr_t ConstructInAddrT(uint8_t a, uint8_t b,
 						    uint8_t c, uint8_t d) noexcept {
 		return ToBE32((a << 24) | (b << 16) | (c << 8) | d);

--- a/src/plugin.cxx
+++ b/src/plugin.cxx
@@ -23,6 +23,9 @@
 #include <sys/wait.h>
 
 #ifdef __APPLE__
+#include <crt_externs.h>
+#define environ (*_NSGetEnviron())
+#else
 extern char **environ;
 #endif
 


### PR DESCRIPTION
Fixes: https://github.com/MusicPlayerDaemon/ncmpc/issues/130