### PR TITLE
Fix config file overriding environment variable

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,7 @@ ncmpc 0.50 - not yet released
 * build: require Meson 0.56
 * lyrics/musixmatch: add new lyrics extension
 * lyrics/google: fix partial loading of lyrics
+* fix config file overriding MPD_HOST environment variable
 
 ncmpc 0.49 - (2023-08-04)
 * fix UI freeze if lyrics plugin is stuck

--- a/src/Main.cxx
+++ b/src/Main.cxx
@@ -301,6 +301,9 @@ try {
 	GetGlobalKeyBindings().Check(nullptr, 0);
 #endif
 
+	/* set options from environment variables */
+	options_env();
+
 	/* parse command line options - 2 pass */
 	options_parse(argc, argv);
 

--- a/src/Options.cxx
+++ b/src/Options.cxx
@@ -320,7 +320,11 @@ options_parse(int argc, const char *argv[])
 		handle_option(opt->shortopt, nullptr);
 	else if (opt && opt->argument)
 		option_error(ERROR_MISSING_ARGUMENT, opt->longopt, opt->argument);
+}
 
-	if (options.host.empty() && getenv("MPD_HOST"))
+void
+options_env()
+{
+	if (getenv("MPD_HOST"))
 		options.host = getenv("MPD_HOST");
 }

--- a/src/Options.hxx
+++ b/src/Options.hxx
@@ -97,4 +97,6 @@ extern Options options;
 
 void options_parse(int argc, const char **argv);
 
+void options_env();
+
 #endif


### PR DESCRIPTION
The convention for most programs is that command line options override environment variables which in turn override config files. Removed the test for empty as the option should be overridden unconditionally if it exists in the environment.

In the old implementation, the host was set from the environment variable in the first pass and then overridden by the config file in the second pass.

Reading the environment variable is currently part of the minified version (`NCMPC_MINI`), not sure if that's desired.