### PR TITLE
fix(util): add missing include to fix the clang build failure

### DIFF
--- a/src/util/StringUTF8.cxx
+++ b/src/util/StringUTF8.cxx
@@ -5,6 +5,7 @@
 #include "StringAPI.hxx"
 
 #include <string.h>
+#include <xlocale.h>
 
 #ifdef HAVE_LOCALE_T
 #include <langinfo.h>


### PR DESCRIPTION
```
  FAILED: [code=1] src/util/libutil.a.p/StringUTF8.cxx.o 
  clang++ -Isrc/util/libutil.a.p -Isrc/util -I../src/util -Isrc -I../src -I. -I.. -fdiagnostics-color=always -D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_FAST -Wall -Winvalid-pch -Wextra -Wpedantic -std=c++20 -O3 -Wcast-qual -Wcast-align -Wdouble-promotion -Wmissing-declarations -Wmissing-format-attribute -Wmissing-noreturn -Wredundant-decls -Wshadow -Wundef -Wvla -Wwrite-strings -Wunreachable-code-aggressive -Wused-but-marked-unused -fno-threadsafe-statics -fmerge-all-constants -Wextra-semi -Wmismatched-tags -Woverloaded-virtual -Wsign-promo -Wno-non-virtual-dtor -Wno-format-truncation -Wcomma -Wheader-hygiene -Winconsistent-missing-destructor-override -D_GNU_SOURCE -fvisibility=hidden -ffunction-sections -fdata-sections -MD -MQ src/util/libutil.a.p/StringUTF8.cxx.o -MF src/util/libutil.a.p/StringUTF8.cxx.o.d -o src/util/libutil.a.p/StringUTF8.cxx.o -c ../src/util/StringUTF8.cxx
  ../src/util/StringUTF8.cxx:52:10: error: use of undeclared identifier 'strcoll_l'
     52 |                 return strcoll_l(a, b, utf8_locale);
        |                        ^
  1 error generated.
```

- https://github.com/Homebrew/homebrew-core/pull/244222